### PR TITLE
feature/add-support-for-reading-from-buffers

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -38,6 +38,20 @@ class TestReadMethods(unittest.TestCase):
             test = obj.get_frame(z=z, t=t, c=c)
             self.assertEqual(test.tobytes(), ref.tobytes())
 
+    def test_image_loading_from_buffer(self):
+        # order = c, z, t
+        test_array = [[0, 0, 0], [0, 2, 0], [0, 2, 2], [1, 0, 0]]
+        for i in test_array:
+            c = str(i[0])
+            z = str(i[1])
+            t = str(i[2])
+            ref = Image.open("./tests/tiff/c" + c + "z" + z + "t" + t + ".tif")
+
+            with open("./tests/xyzt_test.lif", "rb") as open_f:
+                obj = LifFile(open_f).get_image(0)
+                test = obj.get_frame(z=z, t=t, c=c)
+                self.assertEqual(test.tobytes(), ref.tobytes())
+
     def test_XML_header(self):
         etroot, test = get_xml("./tests/xyzt_test.lif")
         self.assertEqual(


### PR DESCRIPTION
Hey @nimne, I am _finally_ getting around to upgrading the `aicsimageio` 4.x `LifReader` to use the new `readlif==0.4.x`.

AICSImageIO 4.x promises support for local and remote file reading and writing, and in trying to use `readlif` noticed you are handling bare pathlikes. Just a simple addition + tests for conditional routing of buffer support.

Thanks again for your work on this library! Hoping to get the `aicsimageio` `LifReader` all handled soon.