### PR TITLE
Fix for new LasX version

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ This has only been tested on Lif files that were generated with Leica LAS X and 
 
 Changelog
 ======
+#### 0.6.3
+- Added support for updated LasX with additional data in the Lif file
+
+
 #### 0.6.2
 - Fixed bug where the time and image scale were calculated incorrectly
 - Clarified scaling documentation documentation


### PR DESCRIPTION
Fix for #31. This code should not affect prior file versions. The fix identifies 'offsets' (memory blocks) that are not image files.