### PR TITLE
Change names to include preceeding folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Changelog
 ======
 #### 0.6.2
 - Fixed bug where the time and image scale were calculated incorrectly
-- Clarified scaling documentation documentation
+- Clarified scaling documentation
 
 
 #### 0.6.1

--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -652,12 +652,12 @@ class LifFile:
                     "dims_n": dims_dict,
                     "scale_n": scale_dict,
                     "path": str(path + "/"),
-                    "name": item.attrib["Name"],
+                    "name": '/'.join((str(path + "/") + item.attrib["Name"]).split("/")[1:]),
                     "channels": n_channels,
                     "scale": (scale_x, scale_y, scale_z, scale_t),
                     "bit_depth": bit_depth,
                     "mosaic_position": m_pos_list,
-                    # "metadata_xmlroot": metadata_xmlroot
+                    # "metadata_xml": item
                 }
 
                 return_list.append(data_dict)


### PR DESCRIPTION
File names (when viewed as a list) currently do not display the full 'path'. This makes working with a lot of images in downstream projects difficult.

Changed how image names are determined.