### PR TITLE
Retrieve ATLConfocalSettingDefinition per image

### DIFF
--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -69,6 +69,8 @@ class LifImage:
         mosaic_position (list): If the image is a mosaic (tiled), this contains
             a list of tuples with four values: `(FieldX, FieldY, PosX, PosY)`.
             The length of this list is equal to the number of tiles.
+        settings (dict): ATLConfocalSettingDefinition (if it exists), which contains
+            values like NumericalAperture and Magnification.
         info (dict): Direct access to data dict from LifFile, this is most
             useful for debugging. These are values pulled from the Leica XML.
 

--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -93,6 +93,7 @@ class LifImage:
         self.mosaic_position = image_info["mosaic_position"]
         self.n_mosaic = int(image_info["dims"].m)
         self.channel_as_second_dim = bool(image_info["channel_as_second_dim"])
+        self.settings = image_info["settings"]
 
     def __repr__(self):
         return repr('LifImage object with dimensions: ' + str(self.dims))
@@ -697,6 +698,12 @@ class LifFile:
 
                 Dims = namedtuple("Dims", "x y z t m")
 
+                settings = item.findall("./Data/Image/Attachment/ATLConfocalSettingDefinition")
+                if len(settings) > 0:
+                    settings = settings[0].attrib
+                else:
+                    settings = {}
+
                 data_dict = {
                     "dims": Dims(dim_x, dim_y, dim_z, dim_t, dim_m),
                     "display_dims": (dim1, dim2),
@@ -708,7 +715,8 @@ class LifFile:
                     "scale": (scale_x, scale_y, scale_z, scale_t),
                     "bit_depth": bit_depth,
                     "mosaic_position": m_pos_list,
-                    "channel_as_second_dim": channel_as_second_dim
+                    "channel_as_second_dim": channel_as_second_dim,
+                    "settings": settings
                     # "metadata_xml": item
                 }
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -194,6 +194,10 @@ class TestReadMethods(unittest.TestCase):
         obj = LifFile("./tests/new_lasx.lif")
         self.assertEqual(len(obj.image_list), 1)
 
+    def test_settings(self):
+        obj = LifFile("./tests/testdata_2channel_xz.lif").get_image(0)
+        self.assertEqual(obj.settings["ObjectiveNumber"], '11506353')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi, thanks for your library!

I'm currently doing data processing on STED images where I need some information from the ATLConfocalSettingDefinition. I could parse the XML seperately and then try to match them to the images generated with readlif, but I feel like this approach is cleaner. 

ATLConfocalSettingDefinition is located inside <Attachment Name="HardwareSetting"> of the XML of each Image. It contains useful information like NumericalAperture and Magnification. This PR adds its attributes as a dict to the LifImage class (as `self.settings`). 

Possible drawbacks:
- This is a very specific feature.
"ATLConfocalSettingDefinition" seems to exist in all the test files. However, if you think this is too specific, maybe instead I could create an option (when creating the LifFile) that allows the full XML data per Image to be added to the LifImage object, which would allow users to then parse this manually. That would at least solve the issue of separately going through the whole tree and matching the XML to the images. 

I've added documentation and a very simple test as well.