### PR TITLE
fix z ordering issue

### DIFF
--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -644,7 +644,7 @@ class LifFile:
                     bytes_inc_channel = channel_max
                     cytes_inc_z = int(dims[2].attrib["BytesInc"])
 
-                    channel_as_second_dim = bytes_inc_channel > cytes_inc_z
+                    channel_as_second_dim = bytes_inc_channel < cytes_inc_z
 
                 else:
                     channel_as_second_dim = False


### PR DESCRIPTION
Here is the reasoning for the proposed change from the original post: 
I tried to line 647 in reader.py from: 
```
                if 3 in dims_dict.keys() and len(dims) > 2:
                    channels = item.findall("./Data/Image/ImageDescription/"
                                            "Channels/ChannelDescription")
                    channel_max = sum([int(c.attrib["BytesInc"]) for c in channels])

                    bytes_inc_channel = channel_max
                    cytes_inc_z = int(dims[2].attrib["BytesInc"])

                    channel_as_second_dim = bytes_inc_channel > cytes_inc_z

                else:
                    channel_as_second_dim = False
```
to:
```
                if 3 in dims_dict.keys() and len(dims) > 2:
                    channels = item.findall("./Data/Image/ImageDescription/"
                                            "Channels/ChannelDescription")
                    channel_max = sum([int(c.attrib["BytesInc"]) for c in channels])

                    bytes_inc_channel = channel_max
                    cytes_inc_z = int(dims[2].attrib["BytesInc"])

                    channel_as_second_dim = bytes_inc_channel < cytes_inc_z

                else:
                    channel_as_second_dim = False
```

To tell whether channel is the second dimension, the original code tries to do so by comparing the "byte jump" ("BytesInc" attribute of channels) to the "BytesInc" of z dimension.
In my humble opinion, I feel it is more reasonable to tell by checking the value of "BytesInc" of z dimension. In my case, both the x and y axis size are 1024 pixels with 16 bits depth. With "BytesInc" of z dimension being 12582912 (1024 * 1024 * 2 * 6) I feel channel should not be the second dimension...

```
         <dimensions>
          <dimensiondescription bitinc="0" bytesinc="2" dimid="1" length="9.226190e-05" numberofelements="1024" 
              origin="1.376765e-20" unit="m">
          </dimensiondescription>
          <dimensiondescription bitinc="0" bytesinc="2048" dimid="2" length="9.226190e-05" numberofelements="1024" 
              origin="1.376765e-20" unit="m">
          </dimensiondescription>
          <dimensiondescription bitinc="0" bytesinc="12582912" dimid="3" length="1.799585e-06" numberofelements="7" 
              origin="-6.220585e-06" unit="m">
          </dimensiondescription>
         </dimensions>
```

The original comment is here: https://github.com/nimne/readlif/issues/44#issuecomment-1915429772 
I have tested with couples of images I have and results turned out to be correct it seemed.
If possible, would you please do perform a more extensive test before the merge?

Thanks a lot!
Alan

