### PR TITLE
Add ruff for formatting and linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-# Ignoring W503, because it is difficult to make pretty equations
-ignore = D203, W503
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,.tox
-max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ readlif.egg-info
 #Ignore all compiled python files (e.g. from running the unit tests):
 *.pyc
 *.pyo
-*.py{}
-*.py-e
 
 #Ignore testing files
 ignore.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: lint
+lint:
+	ruff check --exit-zero .
+
+.PHONY: format
+format:
+	ruff format .
+	ruff check --fix .

--- a/envs/dev.yml
+++ b/envs/dev.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - poetry=1.8.2
+  - python=3.12.0
+  pip:
+    - ruff==0.6.2

--- a/readlif/reader.py
+++ b/readlif/reader.py
@@ -1,11 +1,12 @@
-import struct
-import xml.etree.ElementTree as ET
-from PIL import Image
-from collections import namedtuple
-import warnings
-from functools import reduce
-import os
 import io
+import os
+import struct
+import warnings
+import xml.etree.ElementTree as ET
+from collections import namedtuple
+from functools import reduce
+
+from PIL import Image
 
 
 class LifImage:
@@ -98,11 +99,12 @@ class LifImage:
         self.settings = image_info["settings"]
 
     def __repr__(self):
-        return repr('LifImage object with dimensions: ' + str(self.dims))
+        return repr("LifImage object with dimensions: " + str(self.dims))
 
     def _get_len_nondisplay_dims(self):
-        non_display_dims_len = [self.dims_n[d] for d in self.dims_n.keys()
-                                if d not in self.display_dims]
+        non_display_dims_len = [
+            self.dims_n[d] for d in self.dims_n.keys() if d not in self.display_dims
+        ]
         if len(non_display_dims_len) >= 2:
             len_nondisplay = reduce(lambda x, y: x * y, non_display_dims_len)
             # Todo: Check if this is needed..
@@ -127,7 +129,7 @@ class LifImage:
         """
         n = int(n)
 
-        seek_distance = (self.channels * self._get_len_nondisplay_dims())
+        seek_distance = self.channels * self._get_len_nondisplay_dims()
 
         if n >= seek_distance:
             raise ValueError("Invalid item trying to be retrieved.")
@@ -138,8 +140,7 @@ class LifImage:
             image = self.filename
         else:
             raise TypeError(
-                f"expected str, bytes, os.PathLike, or io.IOBase, "
-                f"not {type(self.filename)}"
+                f"expected str, bytes, os.PathLike, or io.IOBase, " f"not {type(self.filename)}"
             )
 
         # self.offsets[1] is the length of the image
@@ -169,18 +170,15 @@ class LifImage:
         # len(data) is the number of bytes (8-bit)
         # However, it is safer to let the lif file tell us the resolution
         if self.bit_depth[0] == 8:
-            return Image.frombytes("L",
-                                   (self.dims_n[self.display_dims[0]],
-                                    self.dims_n[self.display_dims[1]]),
-                                   data)
+            return Image.frombytes(
+                "L", (self.dims_n[self.display_dims[0]], self.dims_n[self.display_dims[1]]), data
+            )
         elif self.bit_depth[0] <= 16:
-            return Image.frombytes("I;16",
-                                   (self.dims_n[self.display_dims[0]],
-                                    self.dims_n[self.display_dims[1]]),
-                                   data)
+            return Image.frombytes(
+                "I;16", (self.dims_n[self.display_dims[0]], self.dims_n[self.display_dims[1]]), data
+            )
         else:
-            raise ValueError("Unknown bit-depth, please submit a bug report"
-                             " on Github")
+            raise ValueError("Unknown bit-depth, please submit a bug report" " on Github")
 
     def get_plane(self, display_dims=None, c=0, requested_dims=None):
         """
@@ -210,10 +208,12 @@ class LifImage:
             raise ValueError("display_dims must be a two value tuple")
 
         if requested_dims.keys() in display_dims:
-            warnings.warn("One or more of the display_dims is in the "
-                          "requested_dims dictionary. Currently this has no "
-                          "effect. All data from the display_dims will be "
-                          "returned.")
+            warnings.warn(
+                "One or more of the display_dims is in the "
+                "requested_dims dictionary. Currently this has no "
+                "effect. All data from the display_dims will be "
+                "returned."
+            )
 
         if display_dims != self.display_dims:
             raise NotImplementedError("Arbitrary dimensions are not yet supported")
@@ -225,8 +225,7 @@ class LifImage:
         # Check if any of the dims exceeds what is in the image
         for i in self.dims_n.keys():
             if (requested_dims[i] + 1) > self.dims_n.get(i, 0):
-                raise ValueError(f"Requested frame in dimension {str(i)} "
-                                 f"doesn't exist")
+                raise ValueError(f"Requested frame in dimension {str(i)} " f"doesn't exist")
 
         if isinstance(self.filename, (str, bytes, os.PathLike)):
             image = open(self.filename, "rb")
@@ -234,26 +233,28 @@ class LifImage:
             image = self.filename
         else:
             raise TypeError(
-                f"expected str, bytes, os.PathLike, or io.IOBase, "
-                f"not {type(self.filename)}"
+                f"expected str, bytes, os.PathLike, or io.IOBase, " f"not {type(self.filename)}"
             )
 
         # Read the specified data into the buffer
         with open(self.filename, "rb") as image:
             # Start at the beginning of the specified image
             image.seek(self.offsets[0])
-            data = bytes()
+            data = b""
 
             # This code is here for future flexibility, to define a range to return
             display_x = range(0, self.dims_n[display_dims[0]])
             display_y = range(0, self.dims_n[display_dims[1]])
 
-            dim_len = [self.dims_n[i] for i in self.dims_n.keys()]  # For calculations below - list of dimension lengths
+            dim_len = [
+                self.dims_n[i] for i in self.dims_n.keys()
+            ]  # For calculations below - list of dimension lengths
             key_idx = range(0, len(dim_len))  # For calculations below
 
             # Note, this does not include the first dim, need to index i - 1 later
-            precalc_dim_prod = tuple([reduce(lambda x, y: x * y, dim_len[:i])
-                                      for i in key_idx if len(dim_len[:i]) > 0])
+            precalc_dim_prod = tuple(
+                [reduce(lambda x, y: x * y, dim_len[:i]) for i in key_idx if len(dim_len[:i]) > 0]
+            )
 
             # Define the size of the plane to return
             total_len = self.dims_n[display_dims[0]] * self.dims_n[display_dims[1]]
@@ -289,10 +290,13 @@ class LifImage:
                         requested_dims[display_dims[0]] = pos_x
                         requested_dims[display_dims[1]] = pos_y
                         for key, i in zip(self.dims_n.keys(), key_idx):
-                            # Multiply requested n dims by the length of all dims below n in the hierarchy
+                            # Multiply requested n dims by the length of all dims below n
+                            # in the hierarchy
                             remaining_dims = dim_len[:i]
                             if len(remaining_dims) > 0:
-                                px_pos += requested_dims[key] * precalc_dim_prod[i - 1] * self.channels
+                                px_pos += (
+                                    requested_dims[key] * precalc_dim_prod[i - 1] * self.channels
+                                )
                             else:
                                 px_pos += requested_dims[key] * self.channels
                         if self.offsets[1] == 0:
@@ -310,18 +314,15 @@ class LifImage:
         # len(data) is the number of bytes (8-bit)
         # However, it is safer to let the lif file tell us the resolution
         if self.bit_depth[0] == 8:
-            return Image.frombytes("L",
-                                   (self.dims_n[display_dims[0]],
-                                    self.dims_n[display_dims[1]]),
-                                   data)
+            return Image.frombytes(
+                "L", (self.dims_n[display_dims[0]], self.dims_n[display_dims[1]]), data
+            )
         elif self.bit_depth[0] <= 16:
-            return Image.frombytes("I;16",
-                                   (self.dims_n[display_dims[0]],
-                                    self.dims_n[display_dims[1]]),
-                                   data)
+            return Image.frombytes(
+                "I;16", (self.dims_n[display_dims[0]], self.dims_n[display_dims[1]]), data
+            )
         else:
-            raise ValueError("Unknown bit-depth, please submit a bug report"
-                             " on Github")
+            raise ValueError("Unknown bit-depth, please submit a bug report" " on Github")
 
     def get_frame(self, z=0, t=0, c=0, m=0):
         """
@@ -337,8 +338,9 @@ class LifImage:
             Pillow Image object
         """
         if self.display_dims != (1, 2):
-            raise ValueError("Atypical imaging experiment, please use "
-                             "get_plane() instead of get_frame()")
+            raise ValueError(
+                "Atypical imaging experiment, please use " "get_plane() instead of get_frame()"
+            )
 
         t = int(t)
         c = int(c)
@@ -461,7 +463,7 @@ class LifImage:
 
 def _read_long(handle):
     """Reads eight bytes, returns the long (Private)."""
-    long_data, = struct.unpack("Q", handle.read(8))
+    (long_data,) = struct.unpack("Q", handle.read(8))
     return long_data
 
 
@@ -482,8 +484,10 @@ def _check_magic(handle, bool_return=False):
     else:
         if not bool_return:
             handle.close()
-            raise ValueError("This is probably not a LIF file. "
-                             "Expected LIF magic byte at " + str(handle.tell()))
+            raise ValueError(
+                "This is probably not a LIF file. "
+                "Expected LIF magic byte at " + str(handle.tell())
+            )
         else:
             return False
 
@@ -501,7 +505,7 @@ def _check_mem(handle, bool_return=False):
 
 def _read_int(handle):
     """Reads four bytes, returns the int (Private)."""
-    int_data, = struct.unpack("I", handle.read(4))
+    (int_data,) = struct.unpack("I", handle.read(4))
     return int_data
 
 
@@ -520,7 +524,8 @@ class LifFile:
     the image and data.
 
     This is based on the java openmicroscopy bioformats lif reading code
-    that is here: https://github.com/openmicroscopy/bioformats/blob/master/components/formats-gpl/src/loci/formats/in/LIFReader.java # noqa
+    that is here:
+    https://github.com/openmicroscopy/bioformats/blob/master/components/formats-gpl/src/loci/formats/in/LIFReader.java
 
     Attributes:
         xml_header (string): The LIF xml header with tons of data
@@ -557,9 +562,7 @@ class LifFile:
             children = tree.findall("./Element")
         for item in children:
             has_sub_children = len(item.findall("./Children/Element/Data")) > 0
-            is_image = (
-                len(item.findall("./Data/Image")) > 0
-            )
+            is_image = len(item.findall("./Data/Image")) > 0
 
             # Check to see if the Memblock idnetified in the XML actually has a size,
             # otherwise it won't have an offset
@@ -590,16 +593,13 @@ class LifFile:
             # This finds empty folders
             has_sub_children = len(item.findall("./Children/Element/Data")) > 0
 
-            is_image = (
-                len(item.findall("./Data/Image")) > 0
-            )
+            is_image = len(item.findall("./Data/Image")) > 0
 
             if is_image:
                 # If additional XML data extraction is needed, add it here.
 
                 # Find the dimensions, get them in order
-                dims = item.findall("./Data/Image/ImageDescription/"
-                                    "Dimensions/")
+                dims = item.findall("./Data/Image/ImageDescription/" "Dimensions/")
 
                 # Get first two dims, if that fails, set X, Y
                 # Todo: Check a 1-d image
@@ -610,9 +610,9 @@ class LifFile:
                     dim1 = 1
                     dim2 = 2
 
-                dims_dict = {int(d.attrib["DimID"]):
-                             int(d.attrib["NumberOfElements"])
-                             for d in dims}
+                dims_dict = {
+                    int(d.attrib["DimID"]): int(d.attrib["NumberOfElements"]) for d in dims
+                }
 
                 # Get the scale from each image
                 scale_dict = {}
@@ -625,20 +625,19 @@ class LifFile:
                         # other conversion factor for times needed
                         # returns scale in frames per second
                         if dim_n == 4:
-                            scale_dict[dim_n] = ((int(dims_dict[dim_n]) - 1)
-                                                 / float(len_n))
+                            scale_dict[dim_n] = (int(dims_dict[dim_n]) - 1) / float(len_n)
                         # Convert from meters to micrometers
                         else:
-                            scale_dict[dim_n] = ((int(dims_dict[dim_n]) - 1)
-                                                 / (float(len_n) * 10**6))
+                            scale_dict[dim_n] = (int(dims_dict[dim_n]) - 1) / (float(len_n) * 10**6)
                     except (AttributeError, ZeroDivisionError):
                         scale_dict[dim_n] = None
 
                 # Hack-y fix to determine if the channel dimension cones after Z
                 # Check if there even is a z dimension
                 if 3 in dims_dict.keys() and len(dims) > 2:
-                    channels = item.findall("./Data/Image/ImageDescription/"
-                                            "Channels/ChannelDescription")
+                    channels = item.findall(
+                        "./Data/Image/ImageDescription/" "Channels/ChannelDescription"
+                    )
                     channel_max = sum([int(c.attrib["BytesInc"]) for c in channels])
 
                     bytes_inc_channel = channel_max
@@ -684,8 +683,7 @@ class LifFile:
                 )
                 n_channels = int(len(channel_list))
                 # Iterate over each channel, get the resolution
-                bit_depth = tuple([int(c.attrib["Resolution"]) for
-                                   c in channel_list])
+                bit_depth = tuple([int(c.attrib["Resolution"]) for c in channel_list])
 
                 # Get the position data if the image is tiled
                 m_pos_list = []
@@ -712,13 +710,13 @@ class LifFile:
                     "dims_n": dims_dict,
                     "scale_n": scale_dict,
                     "path": str(path + "/"),
-                    "name": '/'.join((str(path + "/") + item.attrib["Name"]).split("/")[1:]),
+                    "name": "/".join((str(path + "/") + item.attrib["Name"]).split("/")[1:]),
                     "channels": n_channels,
                     "scale": (scale_x, scale_y, scale_z, scale_t),
                     "bit_depth": bit_depth,
                     "mosaic_position": m_pos_list,
                     "channel_as_second_dim": channel_as_second_dim,
-                    "settings": settings
+                    "settings": settings,
                     # "metadata_xml": item
                 }
 
@@ -739,8 +737,7 @@ class LifFile:
             f = filename
         else:
             raise TypeError(
-                f"expected str, bytes, os.PathLike, or io.IOBase, "
-                f"not {type(filename)}"
+                f"expected str, bytes, os.PathLike, or io.IOBase, " f"not {type(filename)}"
             )
         f_len = _get_len(f)
 
@@ -780,9 +777,11 @@ class LifFile:
             except ValueError:
                 if _check_truncated(f):
                     truncation_begin = f.tell()
-                    warnings.warn("LIF file is likely truncated. Be advised, "
-                                  "it appears that some images are blank. ",
-                                  UserWarning)
+                    warnings.warn(
+                        "LIF file is likely truncated. Be advised, "
+                        "it appears that some images are blank. ",
+                        UserWarning,
+                    )
                     truncated = True
                     f.seek(0, 2)
 
@@ -798,7 +797,7 @@ class LifFile:
         # the LIF magic bytes aren't present to guide the location.
         if truncated:
             num_truncated = len(self.image_list) - len(self.offsets)
-            for i in range(num_truncated):
+            for _ in range(num_truncated):
                 # In the special case of a truncation,
                 # append an offset with length zero.
                 # This will be taken care of later when the images are retrieved.
@@ -809,22 +808,23 @@ class LifFile:
             is_image_bool_list = self._recursive_memblock_is_image(self.xml_root)
             if False in is_image_bool_list:
                 from itertools import compress
+
                 self.offsets = list(compress(self.offsets, is_image_bool_list))
 
         if len(self.image_list) != len(self.offsets) and not truncated:
-            raise ValueError("Number of images is not equal to number of "
-                             "offsets, and this file does not appear to "
-                             "be truncated. Something has gone wrong.")
+            raise ValueError(
+                "Number of images is not equal to number of "
+                "offsets, and this file does not appear to "
+                "be truncated. Something has gone wrong."
+            )
         else:
             self.num_images = len(self.image_list)
 
     def __repr__(self):
         if self.num_images == 1:
-            return repr('LifFile object with ' + str(self.num_images)
-                        + ' image')
+            return repr("LifFile object with " + str(self.num_images) + " image")
         else:
-            return repr('LifFile object with ' + str(self.num_images)
-                        + ' images')
+            return repr("LifFile object with " + str(self.num_images) + " images")
 
     def get_image(self, img_n=0):
         """

--- a/readlif/utilities.py
+++ b/readlif/utilities.py
@@ -1,5 +1,6 @@
-from readlif.reader import _check_magic, _check_mem, _read_int
 import xml.etree.ElementTree as ET
+
+from readlif.reader import _check_magic, _check_mem, _read_int
 
 
 def get_xml(filename):

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,6 +13,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [lint]
+# TODO: revisit this ignored rule ("No explicit `stacklevel` keyword argument found").
 ignore = ["B028"]
 unfixable = []
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,39 @@
+line-length = 100
+indent-width = 4
+
+extend-include = ["*.ipynb"]
+
+[format]
+# Like Black, use double quotes, indent with spaces, and respect trailing commas.
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[lint]
+ignore = []
+unfixable = []
+fixable = ["ALL"]
+
+select = [
+    # flake8-bugbear
+    "B",
+    # pycodestyle error
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+    # pyupgrade
+    "UP",
+    # pycodestyle warning
+    "W",
+]
+
+[lint.per-file-ignores]
+# Ignore star and unused imports.
+"__init__.py" = ["F403", "F405"]
+
+[lint.isort]
+order-by-type = true
+no-lines-before = ["future", "standard-library"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,8 @@
 line-length = 100
 indent-width = 4
 
+include = ["readlif/**/*.py", "tests/**/*.py"]
+
 extend-include = ["*.ipynb"]
 
 [format]
@@ -11,7 +13,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [lint]
-ignore = []
+ignore = ["B028"]
 unfixable = []
 fixable = ["ALL"]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,15 +1,18 @@
-import unittest
 import os
+import unittest
+
+from PIL import Image
+
 from readlif.reader import LifFile
 from readlif.utilities import get_xml
-from PIL import Image
 
 # Todo: Test a truncated image
 
 
 def downloadPrivateFile(filename):
     import requests
-    pwd = os.environ.get('READLIF_TEST_DL_PASSWD')
+
+    pwd = os.environ.get("READLIF_TEST_DL_PASSWD")
 
     dl_url = "https://cdn.nimne.com/readlif/" + str(filename)
 
@@ -17,7 +20,7 @@ def downloadPrivateFile(filename):
         os.makedirs("./tests/private/")
 
     if not os.path.exists("./tests/private/" + filename):
-        with requests.get(dl_url, stream=True, auth=('readlif', pwd)) as r:
+        with requests.get(dl_url, stream=True, auth=("readlif", pwd)) as r:
             r.raise_for_status()
             with open("./tests/private/" + filename, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
@@ -54,18 +57,17 @@ class TestReadMethods(unittest.TestCase):
 
     def test_XML_header(self):
         etroot, test = get_xml("./tests/xyzt_test.lif")
-        self.assertEqual(
-            test[:50], '<LMSDataContainerHeader Version="2"><Element Name='
-        )
+        self.assertEqual(test[:50], '<LMSDataContainerHeader Version="2"><Element Name=')
 
     def test_iterators(self):
         images = [i for i in LifFile("./tests/xyzt_test.lif").get_iter_image()]
         self.assertEqual(len(images), 1)
 
         obj = LifFile("./tests/xyzt_test.lif").get_image(0)
-        self.assertEqual(repr(obj), "'LifImage object with "
-                                    "dimensions: "
-                                    "Dims(x=1024, y=1024, z=3, t=3, m=1)'")
+        self.assertEqual(
+            repr(obj),
+            "'LifImage object with " "dimensions: " "Dims(x=1024, y=1024, z=3, t=3, m=1)'",
+        )
 
         c_list = [i for i in obj.get_iter_c()]
         self.assertEqual(len(c_list), 2)
@@ -115,9 +117,10 @@ class TestReadMethods(unittest.TestCase):
         # These tests are for images that are not public.
         # These images will be pulled from a protected web address
         # during CI testing.
-        if os.environ.get('READLIF_TEST_DL_PASSWD') is not None \
-                and os.environ.get('READLIF_TEST_DL_PASSWD') != "":
-
+        if (
+            os.environ.get("READLIF_TEST_DL_PASSWD") is not None
+            and os.environ.get("READLIF_TEST_DL_PASSWD") != ""
+        ):
             downloadPrivateFile("16bit.lif")
             downloadPrivateFile("i1c0z2_16b.tif")
             # Note - readlif produces little endian files,
@@ -138,9 +141,10 @@ class TestReadMethods(unittest.TestCase):
         # These images will be pulled from a protected web address
         # during CI testing.
 
-        if os.environ.get('READLIF_TEST_DL_PASSWD') is not None\
-                and os.environ.get('READLIF_TEST_DL_PASSWD') != "":
-
+        if (
+            os.environ.get("READLIF_TEST_DL_PASSWD") is not None
+            and os.environ.get("READLIF_TEST_DL_PASSWD") != ""
+        ):
             downloadPrivateFile("tile_002.lif")
             downloadPrivateFile("i0c1m2z0.tif")
 
@@ -196,7 +200,7 @@ class TestReadMethods(unittest.TestCase):
 
     def test_settings(self):
         obj = LifFile("./tests/testdata_2channel_xz.lif").get_image(0)
-        self.assertEqual(obj.settings["ObjectiveNumber"], '11506353')
+        self.assertEqual(obj.settings["ObjectiveNumber"], "11506353")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds ruff for formatting and linting. It also includes the initial round of formatting and lint fixes.

The project does not use `pyproject.toml` so the ruff config is added in `ruff.toml`.
